### PR TITLE
Fix the Android publishing pipeline (#37)

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -67,6 +67,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./android/app/build/outputs/apk/release/app-release.apk
+          asset_path: ./android/app/build/outputs/apk/release/app-release-unsigned-signed.apk
           asset_name: swag-app-${{ env.CURRENT_DATE }}.apk
           asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
* Use an existing .apk filename for the final upload step