### PR TITLE
Let android workflow inherit secrets

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/publish-android.yml
     with:
       version: ${{ needs.prepare-data.outputs.DOCKER_TAG }}
+    secrets: inherit
 
   publish-website:
     needs: prepare-data


### PR DESCRIPTION
Apparently secrets aren't implicitly available in reusable workflows, except for GITHUB_TOKEN.